### PR TITLE
Return a BuildError vs raising a RuntimeError for :invalid_properties

### DIFF
--- a/lib/jsv/builder.ex
+++ b/lib/jsv/builder.ex
@@ -461,8 +461,19 @@ defmodule JSV.Builder do
   # top level and the buil path is just [:root] or [ns].
   @spec fail(t, term, term) :: no_return()
   def fail(%__MODULE__{} = builder, reason, action) do
-    build_path = ErrorFormatter.format_schema_path(builder.current_rev_path)
+    {reason, rev_path} = unwrap_resolver_path(reason, builder.current_rev_path)
+    build_path = ErrorFormatter.format_schema_path(rev_path)
 
     raise BuildError.of(reason, action, build_path)
+  end
+
+  # Some resolver errors carry the rev_path where the error occurred, since the
+  # builder's current_rev_path is not yet set during schema resolution.
+  defp unwrap_resolver_path({:invalid_properties, props, rev_path}, _default) do
+    {{:invalid_properties, props}, rev_path}
+  end
+
+  defp unwrap_resolver_path(reason, default) do
+    {reason, default}
   end
 end

--- a/lib/jsv/resolver.ex
+++ b/lib/jsv/resolver.ex
@@ -315,8 +315,8 @@ defmodule JSV.Resolver do
       {"properties", props}, acc when is_map(props) ->
         scan_map_values(props, parent_id, nss, meta, ["properties" | path], acc)
 
-      {"properties", props}, _ ->
-        raise "invalid properties: #{inspect(props)}"
+      {"properties", props}, _acc ->
+        {:error, {:invalid_properties, props}}
 
       {ignored, _}, _ when ignored in ["enum", "const"] ->
         {:ok, acc}

--- a/lib/jsv/resolver.ex
+++ b/lib/jsv/resolver.ex
@@ -316,7 +316,7 @@ defmodule JSV.Resolver do
         scan_map_values(props, parent_id, nss, meta, ["properties" | path], acc)
 
       {"properties", props}, _acc ->
-        {:error, {:invalid_properties, props}}
+        {:error, {:invalid_properties, props, ["properties" | path]}}
 
       {ignored, _}, _ when ignored in ["enum", "const"] ->
         {:ok, acc}

--- a/test/jsv/builder_test.exs
+++ b/test/jsv/builder_test.exs
@@ -37,6 +37,20 @@ defmodule JSV.BuilderTest do
              } = err
     end
 
+    test "returns a build error for a bad properties value" do
+      raw_schema = %{
+        properties: "bad-value"
+      }
+
+      assert {:error, err} = JSV.build(raw_schema)
+
+      assert %{
+               reason: {:invalid_properties, "bad-value"},
+               action: {JSV.Resolver, :resolve, _},
+               build_path: "#"
+             } = err
+    end
+
     # TODO this should be fixed so we get the actual build path for refs
     #
     # test "returns a correct build error for resolver errors" do

--- a/test/jsv/builder_test.exs
+++ b/test/jsv/builder_test.exs
@@ -37,17 +37,39 @@ defmodule JSV.BuilderTest do
              } = err
     end
 
-    test "returns a build error for a bad properties value" do
+    test "returns a build error for an invalid properties value at the root" do
       raw_schema = %{
-        properties: "bad-value"
+        properties: "badmap"
       }
 
       assert {:error, err} = JSV.build(raw_schema)
 
       assert %{
-               reason: {:invalid_properties, "bad-value"},
+               reason: {:invalid_properties, "badmap"},
                action: {JSV.Resolver, :resolve, _},
-               build_path: "#"
+               build_path: "#/properties"
+             } = err
+    end
+
+    test "returns a build error for an invalid properties value deeply nested" do
+      raw_schema = %{
+        properties: %{
+          foo: %{
+            properties: %{
+              bar: %{
+                properties: "badmap"
+              }
+            }
+          }
+        }
+      }
+
+      assert {:error, err} = JSV.build(raw_schema)
+
+      assert %{
+               reason: {:invalid_properties, "badmap"},
+               action: {JSV.Resolver, :resolve, _},
+               build_path: "#/properties/foo/properties/bar/properties"
              } = err
     end
 


### PR DESCRIPTION
👋 Hello, thank you for JSV! I'm currently evaluating using it for a project, and have been very impressed so far. 

One minor thing we ran across recently was `JSV.build/2` raising an `RuntimeError`, which was unexpected given the typespecs (and existence of custom errors like `BuildError`).

An example:

```elixir
JSV.build(%{properties: "bad-value"})
```

While this is undeniably a bad schema argument, I think it would be better if we treated it more similarly to others. Right now, the rescue in `build/2` only catches `BuildError` and `UndefinedFunctionError`, so the `RuntimeError` from `raise "invalid properties: ..."` in `Resolver.scan_map_values/6` bubbles up to crash the caller.

Since we build schemas dynamically, we're currently working around this with `try ... end` blocks, but we're hoping to improve the approach.

## The Fix

1. Returning `{:error, {:invalid_properties, props}}` from the resolver instead of raising lets the error flow through the existing `unwrap_ok_resolver → Builder.fail/3 → raise BuildError.of(...)` pipeline, which `build/2` then rescues and wraps. As far as I can tell, other errors in the resolver already works this way (`:key_exists`, `:unresolved`, `:resolver_error`, etc.), so I think this just brings properties validation in line with the rest.
2. A test case to match

---

Please let me know if I can improve this PR to better suit your expectations (or if I'm just totally off-base with the idea). Thanks!

